### PR TITLE
fix: update default release tag to be latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "private": false,
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "tag": "next"
+    "tag": "latest"
   }
 }


### PR DESCRIPTION
# Summary
The npm release tag in the package.json was overriding all releases to use the `next` tag. This PR updates that to be the `latest` tag, while still allowing branches with the `next` substring to be published to the `next` tag on npm.

Closes #25 