### PR TITLE
chore: bumps version of package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-plugin-newrelic",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "Gatsby plugin for implementing the New Relic Browser agent",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In PR https://github.com/newrelic/gatsby-plugin-newrelic/pull/45 we neglected to bump the version of the package for the next release. 