### PR TITLE
Adjust env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
             trustKey: '<some integer>',
             agentID: '<some integer>',
             licenseKey: '<the license key>',
-            applicationID: process.env.GATSBY_NEWRELIC_ENV === "production" ? '<some integer>' : '<some other integer>',
+            applicationID: process.env.YOUR_ENVIRONMENT_KEY === "production" ? '<some integer>' : '<some other integer>',
             beacon: 'bam.nr-data.net',
             errorBeacon: 'bam.nr-data.net'
         }

--- a/README.md
+++ b/README.md
@@ -63,11 +63,7 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
         }
       }
     }
-    ```
-
-    If you have no need for multiple environments, you can simply pass a single object like:
-
-   
+    ```  
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -27,41 +27,39 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
 
     and turn it into a `gatsby-config`, adding it to `gatsby-config.js` as a plugin
 
+     ```js
+    {
+      resolve: 'gatsby-plugin-newrelic',
+      options: {
+        config: {
+            instrumentationType: 'proAndSPA',
+            accountId: '<some integer>',
+            trustKey: '<some integer>',
+            agentID: '<some integer>',
+            licenseKey: '<the license key>',
+            applicationID: '<some integer>',
+            beacon: 'bam.nr-data.net',
+            errorBeacon: 'bam.nr-data.net'
+        }
+      }
+    }
+    ```
+
+    If you have a need for multiple environments, you can configure this like:
+
     ```js
     {
       resolve: 'gatsby-plugin-newrelic',
       options: {
-        configs: {
-          dev: {
+        config: {
             instrumentationType: 'proAndSPA',
             accountId: '<some integer>',
             trustKey: '<some integer>',
             agentID: '<some integer>',
             licenseKey: '<the license key>',
-            applicationID: '<some integer>',
+            applicationID: process.env.GATSBY_NEWRELIC_ENV === "production" ? '<some integer>' : '<some other integer>',
             beacon: 'bam.nr-data.net',
             errorBeacon: 'bam.nr-data.net'
-          },
-          staging: {
-            instrumentationType: 'proAndSPA',
-            accountId: '<some integer>',
-            trustKey: '<some integer>',
-            agentID: '<some integer>',
-            licenseKey: '<the license key>',
-            applicationID: '<some integer>',
-            beacon: 'bam.nr-data.net',
-            errorBeacon: 'bam.nr-data.net'
-          },
-          production: {
-            instrumentationType: 'proAndSPA',
-            accountId: '<some integer>',
-            trustKey: '<some integer>',
-            agentID: '<some integer>',
-            licenseKey: '<the license key>',
-            applicationID: '<some integer>',
-            beacon: 'bam.nr-data.net',
-            errorBeacon: 'bam.nr-data.net'
-          }
         }
       }
     }
@@ -69,34 +67,7 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
 
     If you have no need for multiple environments, you can simply pass a single object like:
 
-    ```js
-    {
-      resolve: 'gatsby-plugin-newrelic',
-      options: {
-        configs: {
-            instrumentationType: 'proAndSPA',
-            accountId: '<some integer>',
-            trustKey: '<some integer>',
-            agentID: '<some integer>',
-            licenseKey: '<the license key>',
-            applicationID: '<some integer>',
-            beacon: 'bam.nr-data.net',
-            errorBeacon: 'bam.nr-data.net'
-        }
-      }
-    }
-    ```
-
-
-1. Set the `GATSBY_NEWRELIC_ENV` to point at the appropriate config. For local dev you would add `GATSBY_NEWRELIC_ENV=dev` to the front of your "develop" script in your project's `package.json`. For "production" you would add `GATSBY_NEWRELIC_ENV=production` to the front of the Gatsby "build" command.
-    Ex. `package.json`:
-
-    ```js
-      "scripts": {
-        "build": "GATSBY_NEWRELIC_ENV=production gatsby build",
-        "build:dev": "GATSBY_NEWRELIC_ENV=dev npm run build",
-      }
-    ```
+   
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
       resolve: 'gatsby-plugin-newrelic',
       options: {
         configs: {
-          instrumentationType: 'proAndSPA',
+            instrumentationType: 'proAndSPA',
             accountId: '<some integer>',
             trustKey: '<some integer>',
             agentID: '<some integer>',

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -3,7 +3,8 @@ import { liteAgent, proAgent, proAndSpaAgent } from '../browser-agents/latest';
 
 export default ({ setHeadComponents }, pluginOptions) => {
   const {
-    config: userConfigs
+    configs: userConfigs,
+    config: userConfig
   } = pluginOptions;
 
   const requiredConfig = {
@@ -19,7 +20,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
 
   const env = process.env.GATSBY_NEWRELIC_ENV;
 
-  const userEnvConfig = env && userConfigs[env] ? userConfigs[env] : userConfigs;
+  const userEnvConfig = env ? userConfigs[env] : userConfig;
   if (!userEnvConfig) {
     console.warn(`gatsby-plugin-newrelic is missing the configuration${env ? ` for the ${env} environment` : ''}`);
     return;

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -21,7 +21,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
 
   const userEnvConfig = env && userConfigs[env] ? userConfigs[env] : userConfigs;
   if (!userEnvConfig) {
-    console.warn(`gatsby-plugin-newrelic is missing the configuration${env && `for the ${env} environment`}`);
+    console.warn(`gatsby-plugin-newrelic is missing the configuration${env ? `for the ${env} environment` : ''}`);
     return;
   }
 

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -3,10 +3,10 @@ import { liteAgent, proAgent, proAndSpaAgent } from '../browser-agents/latest';
 
 export default ({ setHeadComponents }, pluginOptions) => {
   const {
-    configs: userConfigs
+    config: userConfig
   } = pluginOptions;
 
-  const requiredConfigs = {
+  const requiredConfig = {
     accountId: '',
     trustKey: '',
     agentID: '',
@@ -17,11 +17,8 @@ export default ({ setHeadComponents }, pluginOptions) => {
     instrumentationType: 'lite' // Options are 'lite', 'pro', 'proAndSPA'
   };
 
-  const env = process.env.GATSBY_NEWRELIC_ENV;
-
-  const userEnvConfig = env && userConfigs[env] ? userConfigs[env] : userConfigs;
-  if (!userEnvConfig) {
-    console.warn(`gatsby-plugin-newrelic is missing the configuration${env ? `for the ${env} environment` : ''}`);
+  if (!userConfig) {
+    console.warn("gatsby-plugin-newrelic is missing the configuration");
     return;
   }
 
@@ -33,7 +30,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
     // TO DO - Error/Warn about wrong instrumentation type
   }
 
-  const options = { ...requiredConfigs, ...userEnvConfig };
+  const options = { ...requiredConfig, ...userConfig };
   const instrumentationType = options.instrumentationType;
 
   const emptyOptions = Object.entries(options).filter(([, v]) => v === '');

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -3,7 +3,7 @@ import { liteAgent, proAgent, proAndSpaAgent } from '../browser-agents/latest';
 
 export default ({ setHeadComponents }, pluginOptions) => {
   const {
-    config: userConfig
+    config: userConfigs
   } = pluginOptions;
 
   const requiredConfig = {
@@ -17,9 +17,16 @@ export default ({ setHeadComponents }, pluginOptions) => {
     instrumentationType: 'lite' // Options are 'lite', 'pro', 'proAndSPA'
   };
 
-  if (!userConfig) {
-    console.warn("gatsby-plugin-newrelic is missing the configuration");
+  const env = process.env.GATSBY_NEWRELIC_ENV;
+
+  const userEnvConfig = env && userConfigs[env] ? userConfigs[env] : userConfigs;
+  if (!userEnvConfig) {
+    console.warn(`gatsby-plugin-newrelic is missing the configuration${env ? ` for the ${env} environment` : ''}`);
     return;
+  }
+
+  if (env) {
+    console.warn('gatsby-plugin-newrelic has deprecated using GATSBY_NEWRELIC_ENV for multiple environments');
   }
 
   const allowedInstrumentationTypes = ['lite', 'pro', 'proAndSPA'];
@@ -30,7 +37,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
     // TO DO - Error/Warn about wrong instrumentation type
   }
 
-  const options = { ...requiredConfig, ...userConfig };
+  const options = { ...requiredConfig, ...userEnvConfig };
   const instrumentationType = options.instrumentationType;
 
   const emptyOptions = Object.entries(options).filter(([, v]) => v === '');

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -19,16 +19,9 @@ export default ({ setHeadComponents }, pluginOptions) => {
 
   const env = process.env.GATSBY_NEWRELIC_ENV;
 
-  if (!env) {
-    // TO DO - Error/Warn about envVariable not being set
-    console.warn('GATSBY_NEWRELIC_ENV env variable is not set');
-    return;
-  }
-
-  const userEnvConfig = userConfigs[env] ? userConfigs[env] : userConfigs;
+  const userEnvConfig = env && userConfigs[env] ? userConfigs[env] : userConfigs;
   if (!userEnvConfig) {
-    // TO DO - Error/Warn about missing config option for a given env
-    console.warn('gatsby-plugin-newrelic is missing the configuration for the ' + env + ' environment');
+    console.warn(`gatsby-plugin-newrelic is missing the configuration${env && `for the ${env} environment`}`);
     return;
   }
 
@@ -66,7 +59,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
     ;NREUM.info={beacon:"${options.beacon}",errorBeacon:"${options.errorBeacon}",licenseKey:"${options.licenseKey}",applicationID:"${options.applicationID}",sa:1}
   `;
 
-  if (agent && configs) { 
+  if (agent && configs) {
     setHeadComponents([
       <script
         key="gatsby-plugin-newrelic"


### PR DESCRIPTION
This plugins configuration system is needlessly complicated, developers are free to configure environmental options _before_ passing them to the plugin. With the current system, you are forced to set environment variables which might not be readily possible (and varies between unix/windows).

Instead by dropping this concept and accepting a single config this will simplify all scenarios