### PR TITLE
Add support for react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "homepage": "https://opensource.newrelic.com/projects/newrelic/gatsby-plugin-newrelic",
   "peerDependencies": {
     "gatsby": "3.x || 4.x",
-    "react": "^17.0.0",
-    "react-dom": "^17.0.0"
+    "react": "17 - 18",
+    "react-dom": "17 - 18"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #60 

Adds support for both react 17 and 18 as peer dependencies.