### PR TITLE
Add support gatsby.js v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://opensource.newrelic.com/projects/newrelic/gatsby-plugin-newrelic",
   "peerDependencies": {
-    "gatsby": "3.x || 4.x",
+    "gatsby": "3.x - 5.x",
     "react": "17 - 18",
     "react-dom": "17 - 18"
   },


### PR DESCRIPTION
I change peerDependencies
3.x | 4.x -> 3.x - 5.x