### PR TITLE
feat: add support for custom browser agent settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,50 +21,92 @@ The New Relic Gatsby Plugin provides a simple to use configuration option for in
 1. Open your `gatsby-config.js` file for your project
 1. You'll need to copy information from the JS snippet, which looks like this:
 
-    ```js
-    ;NREUM.loader_config={accountID:"<your account id>",trustKey:"<some integer>",agentID:"<some integer>",licenseKey:"<your license key>",applicationID:"<some integer>"}
-    ;NREUM.info={beacon:"bam.nr-data.net",errorBeacon:"bam.nr-data.net",licenseKey:"<your license key>",applicationID:"<some integer>",sa:1}
-    ```
+   ```js
+   // use this line for the `settings` object
+   window.NREUM || (NREUM = {});
+   NREUM.init = {
+     distributed_tracing: { enabled: true },
+     privacy: { cookies_enabled: true },
+     ajax: { deny_list: ["bam-cell.nr-data.net"] },
+   };
 
-    and turn it into a `gatsby-config`, adding it to `gatsby-config.js` as a plugin
+   // use these lines for the `config` object
+   NREUM.loader_config = {
+     accountID: "<your account id>",
+     trustKey: "<some integer>",
+     agentID: "<some integer>",
+     licenseKey: "<your license key>",
+     applicationID: "<some integer>",
+   };
+   NREUM.info = {
+     beacon: "bam.nr-data.net",
+     errorBeacon: "bam.nr-data.net",
+     licenseKey: "<your license key>",
+     applicationID: "<some integer>",
+     sa: 1,
+   };
+   ```
 
-     ```js
-    {
-      resolve: 'gatsby-plugin-newrelic',
-      options: {
-        config: {
-            instrumentationType: 'proAndSPA',
-            accountId: '<some integer>',
-            trustKey: '<some integer>',
-            agentID: '<some integer>',
-            licenseKey: '<the license key>',
-            applicationID: '<some integer>',
-            beacon: 'bam.nr-data.net',
-            errorBeacon: 'bam.nr-data.net'
-        }
+   and turn it into a `gatsby-config` object, adding it to `gatsby-config.js` as a plugin
+
+   ```js
+   {
+    resolve: 'gatsby-plugin-newrelic',
+    options: {
+      config: {
+          instrumentationType: 'proAndSPA',
+          accountId: '<some integer>',
+          trustKey: '<some integer>',
+          agentID: '<some integer>',
+          licenseKey: '<the license key>',
+          applicationID: '<some integer>',
+          beacon: 'bam.nr-data.net',
+          errorBeacon: 'bam.nr-data.net'
+          settings: {
+            distributed_tracing: { enabled: true },
+            privacy: { cookies_enabled: true },
+            ajax: { deny_list: ["bam-cell.nr-data.net"] },
+          }
       }
     }
-    ```
+   }
+   ```
 
-    If you have a need for multiple environments, you can configure this like:
+   If you have a need for multiple environments, you can configure this like:
 
-    ```js
-    {
-      resolve: 'gatsby-plugin-newrelic',
-      options: {
-        config: {
-            instrumentationType: 'proAndSPA',
-            accountId: '<some integer>',
-            trustKey: '<some integer>',
-            agentID: '<some integer>',
-            licenseKey: '<the license key>',
-            applicationID: process.env.YOUR_ENVIRONMENT_KEY === "production" ? '<some integer>' : '<some other integer>',
-            beacon: 'bam.nr-data.net',
-            errorBeacon: 'bam.nr-data.net'
-        }
-      }
-    }
-    ```
+   ```js
+   {
+     resolve: 'gatsby-plugin-newrelic',
+     options: {
+       config: {
+           instrumentationType: 'proAndSPA',
+           accountId: '<some integer>',
+           trustKey: '<some integer>',
+           agentID: '<some integer>',
+           licenseKey: '<the license key>',
+           applicationID: process.env.YOUR_ENVIRONMENT_KEY === "production" ? '<some integer>' : '<some other integer>',
+           beacon: 'bam.nr-data.net',
+           errorBeacon: 'bam.nr-data.net'
+       }
+     }
+   }
+   ```
+
+   If you have selected custom Session Replay values for `block_selector` or `mask_text_selector`, replace the surrounding single quotes(') with back ticks (`)
+
+   ```js
+   {
+       settings: {
+        session_replay: {
+          enabled: true,
+        // block_selector: '[autocomplete="cc-number"], [autocomplete="cc-name"]',
+          block_selector: `[autocomplete="cc-number"], [autocomplete="cc-name"]`,
+        // mask_text_selector: '.className1, #elementID'`,
+          mask_text_selector: `.className1, #elementID`,
+       }
+     }
+   }
+   ```
 
 ## Getting Started
 
@@ -74,7 +116,7 @@ Navigate to [https://one.newrelic.com](https://one.newrelic.com), select the _En
 
 New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorers Hub. You can find this project's topic/threads here:
 
->Add the url for the support thread here
+> Add the url for the support thread here
 
 ## Contributing
 

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -50,116 +50,132 @@ export default ({ setHeadComponents }, pluginOptions) => {
   }
 
   // --- Possible Browser > Application Settings in the NR1 UI and their options ---
-  const { settings } = options;
+  // Do not supply hard coded defaults for missing options. If the key is not provided, let the browser agent handle those values.
+  let init;
+  if (options?.settings) {
+    const {
+      distributed_tracing: dt,
+      session_replay: sr,
+      privacy,
+      ajax,
+    } = options?.settings;
 
-  // 'Distributed tracing'
-  // not present in init string if not enabled
-  let distributedTracingInitString = "";
+    // 'Distributed tracing'
+    let distributedTracingInitString = "";
 
-  if (settings.distributed_tracing?.enabled) {
-    const dt = settings.distributed_tracing;
-
-    // Agent default settings if they are not provided
-    const distributedTracingConfigObject = {
-      enabled: dt.enabled ?? false,
-      exclude_newrelic_header: dt.exclude_newrelic_header ?? undefined,
-      cors_use_newrelic_header: dt.cors_use_newrelic_header ?? undefined,
-      cors_use_tracecontext_headers:
-        dt.cors_use_tracecontext_headers ?? undefined,
-      allowed_origins: dt.allowed_origins
-        ? `${JSON.stringify(dt.allowed_origins)}`
-        : undefined,
-    };
-
-    let distributedTracingConfigString = "";
-
-    for (const key in distributedTracingConfigObject) {
-      distributedTracingConfigString = distributedTracingConfigString.concat(
-        `${key}:${distributedTracingConfigObject[key]},`
-      );
-    }
-
-    distributedTracingInitString = `distributed_tracing:{${distributedTracingConfigString}},`;
-  }
-
-  // 'Session Replay'
-  // not present in init string if not enabled
-  let sessionReplayInitString = "";
-
-  if (settings.session_replay?.enabled) {
-    const sr = settings.session_replay;
-    let maskOptionsString = "";
-
-    // if user selects custom privacy settings:
-
-    // if 'mask_all_inputs' not set, defaults to true and sets these options to its own default values
-    if (sr.mask_all_inputs !== true) {
-      // if no options set and 'mask_all_inputs' = false, agent defaults all to 'false'
-      const maskOptionsObject = {
-        color: sr.mask_input_options?.color ?? false,
-        date: sr.mask_input_options?.date ?? false,
-        datetime_local: sr.mask_input_options?.datetime_local ?? false,
-        email: sr.mask_input_options?.email ?? false,
-        month: sr.mask_input_options?.month ?? false,
-        number: sr.mask_input_options?.number ?? false,
-        range: sr.mask_input_options?.range ?? false,
-        search: sr.mask_input_options?.search ?? false,
-        tel: sr.mask_input_options?.tel ?? false,
-        text: sr.mask_input_options?.text ?? false,
-        time: sr.mask_input_options?.time ?? false,
-        url: sr.mask_input_options?.url ?? false,
-        week: sr.mask_input_options?.week ?? false,
-        text_area: sr.mask_input_options?.text_area ?? false,
-        select: sr.mask_input_options?.select ?? false,
+    if (dt?.enabled) {
+      const distributedTracingConfigObject = {
+        enabled: `enabled:${dt.enabled}`,
+        exclude_newrelic_header: dt.exclude_newrelic_header
+          ? `exclude_newrelic_header:${dt.exclude_newrelic_header}`
+          : "",
+        cors_use_newrelic_header: dt.cors_use_newrelic_header
+          ? `cors_use_newrelic_header:${dt.cors_use_newrelic_header}`
+          : "",
+        cors_use_tracecontext_headers: dt.cors_use_tracecontext_headers
+          ? `cors_use_tracecontext_headers:${dt.cors_use_tracecontext_headers}`
+          : "",
+        allowed_origins: dt.allowed_origins
+          ? `dt.allowed_origins:${JSON.stringify(dt.allowed_origins)}`
+          : "",
       };
 
-      for (const key in maskOptionsObject) {
-        maskOptionsString = maskOptionsString.concat(
-          `${key}:${maskOptionsObject[key]},`
-        );
-      }
+      distributedTracingInitString = `distributed_tracing:{${Object.values(
+        distributedTracingConfigObject
+      )
+        .filter((v) => v !== "")
+        .join(",")}},`;
     }
 
-    // Agent default settings if they are not provided
-    const sessionReplayConfigObject = {
-      enabled: `enabled:${sr.enabled ?? false}`,
-      block_selector: `block_selector:'${sr.block_selector ?? ""}'`,
-      mask_text_selector: `mask_text_selector:'${
-        sr.mask_text_selector ?? "*"
-      }'`,
-      sampling_rate: `sampling_rate:${sr.sampling_rate ?? 50}`,
-      error_sampling_rate: `error_sampling_rate:${
-        sr.error_sampling_rate ?? 50
-      }`,
-      mask_all_inputs: `mask_all_inputs:${sr.mask_all_inputs ?? true}`,
-      collect_fonts: `collect_fonts:${sr.collect_fonts ?? true}`,
-      inline_images: `inline_images:${sr.inline_images ?? false}`,
-      inline_stylesheet: `inline_stylesheet:${sr.inline_stylesheet ?? true}`,
-      mask_input_options: `mask_input_options:{${maskOptionsString}}`,
-    };
+    // 'Session Replay'
+    let sessionReplayInitString = "";
 
-    let sessionReplayConfigString = "";
+    if (sr?.enabled) {
+      let maskOptionsString = "";
+      const mOption = sr.mask_input_options;
 
-    for (const key in sessionReplayConfigObject) {
-      sessionReplayConfigString = sessionReplayConfigString.concat(
-        `${sessionReplayConfigObject[key]},`
-      );
+      // if user selects custom privacy settings:
+      const maskOptionsObject = {
+        color: mOption?.color ? `color:${mOption?.color}` : "",
+        date: mOption?.date ? `date:${mOption?.date}` : "",
+        datetime_local: mOption?.datetime_local
+          ? `datetime_local:${mOption?.datetime_local}`
+          : "",
+        email: mOption?.email ? `email:${mOption?.email}` : "",
+        month: mOption?.month ? `month:${mOption?.month}` : "",
+        number: mOption?.number ? `number:${mOption?.number}` : "",
+        range: mOption?.range ? `range:${mOption?.range}` : "",
+        search: mOption?.search ? `search:${mOption?.search}` : "",
+        tel: mOption?.tel ? `tel:${mOption?.tel}` : "",
+        text: mOption?.text ? `text:${mOption?.text}` : "",
+        time: mOption?.time ? `time:${mOption?.time}` : "",
+        url: mOption?.url ? `url:${mOption?.url}` : "",
+        week: mOption?.week ? `week:${mOption?.week}` : "",
+        text_area: mOption?.text_area ? `text_area:${mOption?.text_area}` : "",
+        select: mOption?.select ? `select:${mOption?.select}` : "",
+      };
+
+      maskOptionsString = `${Object.values(maskOptionsObject)
+        .filter((v) => v !== "")
+        .join(",")}`;
+
+      const sessionReplayConfigObject = {
+        enabled: sr.enabled ? `enabled:${sr.enabled}` : "",
+        block_selector: sr.block_selector
+          ? `block_selector:'${sr.block_selector}'`
+          : "",
+        mask_text_selector: sr.mask_text_selector
+          ? `mask_text_selector:'${sr.mask_text_selector}'`
+          : "",
+        sampling_rate: sr.sampling_rate
+          ? `sampling_rate:${sr.sampling_rate}`
+          : "",
+        error_sampling_rate: sr.error_sampling_rate
+          ? `error_sampling_rate:${sr.error_sampling_rate}`
+          : "",
+        mask_all_inputs: sr.mask_all_inputs
+          ? `mask_all_inputs:${sr.mask_all_inputs}`
+          : "",
+        collect_fonts: sr.collect_fonts
+          ? `collect_fonts:${sr.collect_fonts}`
+          : "",
+        inline_images: sr.inline_images
+          ? `inline_images:${sr.inline_images}`
+          : "",
+        inline_stylesheet: sr.inline_stylesheet
+          ? `inline_stylesheet:${sr.inline_stylesheet}`
+          : "",
+        mask_input_options:
+          maskOptionsString.length > 0
+            ? `mask_input_options:{${maskOptionsString}}`
+            : "",
+      };
+
+      sessionReplayInitString = `session_replay:{${Object.values(
+        sessionReplayConfigObject
+      )
+        .filter((v) => v !== "")
+        .join(",")}},`;
     }
 
-    sessionReplayInitString = `session_replay:{${sessionReplayConfigString}},`;
+    // 'Browser Settings'
+    const privacyInitString = privacy?.cookies_enabled
+      ? `privacy:{cookies_enabled:${privacy?.cookies_enabled}},`
+      : "";
+
+    // 'AJAX request deny list'
+    const ajaxInitString = ajax?.deny_list
+      ? `ajax:{deny_list:${JSON.stringify(ajax?.deny_list)}},`
+      : "";
+
+    init =
+      sessionReplayInitString ||
+      distributedTracingInitString ||
+      privacyInitString ||
+      ajaxInitString
+        ? `;window.NREUM||(NREUM={});NREUM.init={${sessionReplayInitString}${distributedTracingInitString}${privacyInitString}${ajaxInitString}};`
+        : "";
   }
-
-  // 'Browser Settings' - defaults to true
-  const privacyInitString = `privacy:{cookies_enabled:${
-    settings.privacy?.cookies_enabled ?? "true"
-  }},`;
-
-  // 'AJAX request deny list' - ajax:{deny_list:["bam-cell.nr-data.net"]} is default for prod accounts
-  const ajaxInitString = `ajax:{deny_list:${JSON.stringify(
-    settings.ajax?.deny_list ?? ["bam-cell.nr-data.net"]
-  )}},`;
-
-  const init = `;window.NREUM||(NREUM={});NREUM.init={${sessionReplayInitString}${distributedTracingInitString}${privacyInitString}${ajaxInitString}};`;
 
   let agent;
   if (instrumentationType === "lite") {

--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -1,38 +1,41 @@
-import React from 'react';
-import { liteAgent, proAgent, proAndSpaAgent } from '../browser-agents/latest';
+import React from "react";
+import { liteAgent, proAgent, proAndSpaAgent } from "../browser-agents/latest";
 
 export default ({ setHeadComponents }, pluginOptions) => {
-  const {
-    configs: userConfigs,
-    config: userConfig
-  } = pluginOptions;
+  const { configs: userConfigs, config: userConfig } = pluginOptions;
 
   const requiredConfig = {
-    accountId: '',
-    trustKey: '',
-    agentID: '',
-    licenseKey: '',
-    applicationID: '',
-    beacon: 'bam.nr-data.net',
-    errorBeacon: 'bam.nr-data.net',
-    instrumentationType: 'lite' // Options are 'lite', 'pro', 'proAndSPA'
+    accountId: "",
+    trustKey: "",
+    agentID: "",
+    licenseKey: "",
+    applicationID: "",
+    beacon: "bam.nr-data.net",
+    errorBeacon: "bam.nr-data.net",
+    instrumentationType: "lite", // Options are 'lite', 'pro', 'proAndSPA'
   };
 
   const env = process.env.GATSBY_NEWRELIC_ENV;
 
   const userEnvConfig = env ? userConfigs[env] : userConfig;
   if (!userEnvConfig) {
-    console.warn(`gatsby-plugin-newrelic is missing the configuration${env ? ` for the ${env} environment` : ''}`);
+    console.warn(
+      `gatsby-plugin-newrelic is missing the configuration${
+        env ? ` for the ${env} environment` : ""
+      }`
+    );
     return;
   }
 
   if (env) {
-    console.warn('gatsby-plugin-newrelic has deprecated using GATSBY_NEWRELIC_ENV for multiple environments');
+    console.warn(
+      "gatsby-plugin-newrelic has deprecated using GATSBY_NEWRELIC_ENV for multiple environments"
+    );
   }
 
-  const allowedInstrumentationTypes = ['lite', 'pro', 'proAndSPA'];
+  const allowedInstrumentationTypes = ["lite", "pro", "proAndSPA"];
   const itExists = allowedInstrumentationTypes.find(
-    i => i === userEnvConfig.instrumentationType
+    (i) => i === userEnvConfig.instrumentationType
   );
   if (!itExists) {
     // TO DO - Error/Warn about wrong instrumentation type
@@ -41,21 +44,133 @@ export default ({ setHeadComponents }, pluginOptions) => {
   const options = { ...requiredConfig, ...userEnvConfig };
   const instrumentationType = options.instrumentationType;
 
-  const emptyOptions = Object.entries(options).filter(([, v]) => v === '');
+  const emptyOptions = Object.entries(options).filter(([, v]) => v === "");
   if (emptyOptions.length > 0) {
     // TO DO - Warn about missing options
   }
 
+  // --- Possible Browser > Application Settings in the NR1 UI and their options ---
+  const { settings } = options;
+
+  // 'Distributed tracing'
+  // not present in init string if not enabled
+  let distributedTracingInitString = "";
+
+  if (settings.distributed_tracing?.enabled) {
+    const dt = settings.distributed_tracing;
+
+    // Agent default settings if they are not provided
+    const distributedTracingConfigObject = {
+      enabled: dt.enabled ?? false,
+      exclude_newrelic_header: dt.exclude_newrelic_header ?? undefined,
+      cors_use_newrelic_header: dt.cors_use_newrelic_header ?? undefined,
+      cors_use_tracecontext_headers:
+        dt.cors_use_tracecontext_headers ?? undefined,
+      allowed_origins: dt.allowed_origins
+        ? `${JSON.stringify(dt.allowed_origins)}`
+        : undefined,
+    };
+
+    let distributedTracingConfigString = "";
+
+    for (const key in distributedTracingConfigObject) {
+      distributedTracingConfigString = distributedTracingConfigString.concat(
+        `${key}:${distributedTracingConfigObject[key]},`
+      );
+    }
+
+    distributedTracingInitString = `distributed_tracing:{${distributedTracingConfigString}},`;
+  }
+
+  // 'Session Replay'
+  // not present in init string if not enabled
+  let sessionReplayInitString = "";
+
+  if (settings.session_replay?.enabled) {
+    const sr = settings.session_replay;
+    let maskOptionsString = "";
+
+    // if user selects custom privacy settings:
+
+    // if 'mask_all_inputs' not set, defaults to true and sets these options to its own default values
+    if (sr.mask_all_inputs !== true) {
+      // if no options set and 'mask_all_inputs' = false, agent defaults all to 'false'
+      const maskOptionsObject = {
+        color: sr.mask_input_options?.color ?? false,
+        date: sr.mask_input_options?.date ?? false,
+        datetime_local: sr.mask_input_options?.datetime_local ?? false,
+        email: sr.mask_input_options?.email ?? false,
+        month: sr.mask_input_options?.month ?? false,
+        number: sr.mask_input_options?.number ?? false,
+        range: sr.mask_input_options?.range ?? false,
+        search: sr.mask_input_options?.search ?? false,
+        tel: sr.mask_input_options?.tel ?? false,
+        text: sr.mask_input_options?.text ?? false,
+        time: sr.mask_input_options?.time ?? false,
+        url: sr.mask_input_options?.url ?? false,
+        week: sr.mask_input_options?.week ?? false,
+        text_area: sr.mask_input_options?.text_area ?? false,
+        select: sr.mask_input_options?.select ?? false,
+      };
+
+      for (const key in maskOptionsObject) {
+        maskOptionsString = maskOptionsString.concat(
+          `${key}:${maskOptionsObject[key]},`
+        );
+      }
+    }
+
+    // Agent default settings if they are not provided
+    const sessionReplayConfigObject = {
+      enabled: `enabled:${sr.enabled ?? false}`,
+      block_selector: `block_selector:'${sr.block_selector ?? ""}'`,
+      mask_text_selector: `mask_text_selector:'${
+        sr.mask_text_selector ?? "*"
+      }'`,
+      sampling_rate: `sampling_rate:${sr.sampling_rate ?? 50}`,
+      error_sampling_rate: `error_sampling_rate:${
+        sr.error_sampling_rate ?? 50
+      }`,
+      mask_all_inputs: `mask_all_inputs:${sr.mask_all_inputs ?? true}`,
+      collect_fonts: `collect_fonts:${sr.collect_fonts ?? true}`,
+      inline_images: `inline_images:${sr.inline_images ?? false}`,
+      inline_stylesheet: `inline_stylesheet:${sr.inline_stylesheet ?? true}`,
+      mask_input_options: `mask_input_options:{${maskOptionsString}}`,
+    };
+
+    let sessionReplayConfigString = "";
+
+    for (const key in sessionReplayConfigObject) {
+      sessionReplayConfigString = sessionReplayConfigString.concat(
+        `${sessionReplayConfigObject[key]},`
+      );
+    }
+
+    sessionReplayInitString = `session_replay:{${sessionReplayConfigString}},`;
+  }
+
+  // 'Browser Settings' - defaults to true
+  const privacyInitString = `privacy:{cookies_enabled:${
+    settings.privacy?.cookies_enabled ?? "true"
+  }},`;
+
+  // 'AJAX request deny list' - ajax:{deny_list:["bam-cell.nr-data.net"]} is default for prod accounts
+  const ajaxInitString = `ajax:{deny_list:${JSON.stringify(
+    settings.ajax?.deny_list ?? ["bam-cell.nr-data.net"]
+  )}},`;
+
+  const init = `;window.NREUM||(NREUM={});NREUM.init={${sessionReplayInitString}${distributedTracingInitString}${privacyInitString}${ajaxInitString}};`;
+
   let agent;
-  if (instrumentationType === 'lite') {
+  if (instrumentationType === "lite") {
     agent = liteAgent;
   }
 
-  if (instrumentationType === 'pro') {
+  if (instrumentationType === "pro") {
     agent = proAgent;
   }
 
-  if (instrumentationType === 'proAndSPA') {
+  if (instrumentationType === "proAndSPA") {
     agent = proAndSpaAgent;
   }
 
@@ -69,9 +184,9 @@ export default ({ setHeadComponents }, pluginOptions) => {
       <script
         key="gatsby-plugin-newrelic"
         dangerouslySetInnerHTML={{
-          __html: agent + configs
+          __html: init + agent + configs,
         }}
-      />
+      />,
     ]);
   }
 };


### PR DESCRIPTION
### ✨ Summary

- allows users to add their settings from the agent init snippet
- this includes enabling features like distributed tracing

Added code that builds the INIT portion of the browser agent snippet that contains all the custom Application Settings from the Agent UI in NR1.

If no `settings` are added to the config, it will set defaults and not break the agent.

### 🧪 Steps to reproduce

- update the `src/gatsby/on-render-body.js` for this plugin file in the node modules in a project that uses it (like the theme demo) 
- update the `newrelic.config` object in `gatsby-config.js` with a new `settings` key
  - here is an exampe snippet with distributed tracing and session replay options enabled. There is a simpler example in the README:
```
;window.NREUM||(NREUM={});NREUM.init={session_replay:{enabled:true,block_selector:'*',mask_text_selector:'',sampling_rate:10.0,error_sampling_rate:100.0,mask_all_inputs:false,collect_fonts:true,inline_images:false,inline_stylesheet:true,mask_input_options:{color:true,date:true,datetime_local:true,email:true,month:true,number:true,range:true,search:true,tel:true,text:true,time:true,url:true,week:true,text_area:true,select:true,}},distributed_tracing:{enabled:true},privacy:{cookies_enabled:true},ajax:{deny_list:["staging-bam-cell.nr-data.net"]}};
```
- run a `yarn clean && yarn start`
- you should be able to inspect the NREUM object in the browser console and see your settings here: `NREUM.initializedAgents[randomID].config`

### 🔮 Engineering checklist

<!-- Remove any items that do not apply -->

- [x] Relevant documentation including README's or Confluence are updated to reflect these changes
- [x] Code changes are self-documenting or clearly commented/documented

