### PR TITLE
fix: ensure NREUM object exists before setting config properties

### DIFF
--- a/src/gatsby/on-render-body.js
+++ b/src/gatsby/on-render-body.js
@@ -181,7 +181,7 @@ export default ({ setHeadComponents }, pluginOptions) => {
   }
 
   const configs = `
-    ;NREUM.loader_config={accountID:"${options.accountId}",trustKey:"${options.trustKey}",agentID:"${options.agentID}",licenseKey:"${options.licenseKey}",applicationID:"${options.applicationID}"}
+    ;window.NREUM||(NREUM={});NREUM.loader_config={accountID:"${options.accountId}",trustKey:"${options.trustKey}",agentID:"${options.agentID}",licenseKey:"${options.licenseKey}",applicationID:"${options.applicationID}"}
     ;NREUM.info={beacon:"${options.beacon}",errorBeacon:"${options.errorBeacon}",licenseKey:"${options.licenseKey}",applicationID:"${options.applicationID}",sa:1}
   `;
 


### PR DESCRIPTION
Add window.NREUM||(NREUM={}); check to configs script to prevent "NREUM is not defined" error in browser console.

The configs script was trying to set NREUM.loader_config before the NREUM object was initialized, causing runtime errors. This fix ensures NREUM exists before setting properties, matching the pattern used in the init script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)