### PR TITLE
fix: add explicit permissions to CI workflow jobs (NR-560216)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   log-context:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Dump GitHub context
         env:
@@ -42,6 +43,8 @@ jobs:
   job-checkout-and-build:
     if: "!contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -74,6 +77,8 @@ jobs:
   job-generate-third-party-notices:
     runs-on: ubuntu-latest
     needs: job-checkout-and-build
+    permissions:
+      contents: read
     steps:
       - name: Extract source variables
         run: |


### PR DESCRIPTION
Jira - https://new-relic.atlassian.net/browse/NR-560216

## Summary
- Fixes CodeQL alert `actions/missing-workflow-permissions` (3 open findings: [#1](https://github.com/newrelic/gatsby-plugin-newrelic/security/code-scanning/1), [#2](https://github.com/newrelic/gatsby-plugin-newrelic/security/code-scanning/2), [#3](https://github.com/newrelic/gatsby-plugin-newrelic/security/code-scanning/3)) reported in [NR-560216](https://new-relic.atlassian.net/browse/NR-560216).
- Adds an explicit least-privilege `permissions:` block to each job in `.github/workflows/release.yml` that was missing one: `log-context`, `job-checkout-and-build`, and `job-generate-third-party-notices`.
- `job-generate-release` already declares its own `permissions` block, which is why its corresponding alert ([#4](https://github.com/newrelic/gatsby-plugin-newrelic/security/code-scanning/4)) is already marked fixed — this PR follows that same pattern for the remaining jobs.

## Why this is safe / non-breaking
- `log-context` only echoes GitHub Actions context objects — it never checks out code or calls the GitHub API, so it needs `permissions: {}`.
- `job-checkout-and-build` only checks out the repo (`persist-credentials: false`) and runs `npm ci && npm run build` — no GitHub API calls, so `contents: read` is sufficient.
- `job-generate-third-party-notices` checks out the repo and calls `actions/github-script` (branch protection updates) and `ad-m/github-push-action` (git push), but both explicitly pass `secrets.OPENSOURCE_BOT_TOKEN` rather than relying on the default `GITHUB_TOKEN`, so the implicit token here also only needs `contents: read`.
- No job's use of the default `GITHUB_TOKEN` is being narrowed below what it currently uses — this only declares scopes explicitly instead of relying on the (broader) repo/org default, closing the CodeQL finding without changing any workflow behavior.

## Test plan
- [x] Validated the YAML with `yaml.safe_load` — no syntax errors.
- [x] Diffed against `main` to confirm only `permissions` blocks were added, no other lines changed.
- [ ] After merge, confirm the CI workflow run on `main`/`next` completes successfully (checkout, build, third-party-notices, and release jobs all still pass).
- [ ] Confirm CodeQL code scanning alerts #1, #2, #3 auto-resolve on the next scan of `main` after merge.

[NR-560216]: https://new-relic.atlassian.net/browse/NR-560216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ